### PR TITLE
Release v1.1.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "NoteFlix",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Permet d'avoir les scores et avis AlloCiné.fr sur Netflix",
   "icons": {
     "48": "images/logo-48.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noteflix",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Permet d'avoir les scores Allociné.fr sur Netflix",
   "author": "bt0r",
   "keywords": [

--- a/src/dom/Manager.js
+++ b/src/dom/Manager.js
@@ -17,37 +17,16 @@ export default class Manager {
     this.cache = new Cache();
   }
 
-  supports(mutationsRecords) {
-    let isSupported = false;
-    for (const mutationsRecord of mutationsRecords) {
-      if (mutationsRecord.target.classList.contains('jawBoneContainer')) {
-        isSupported = true;
-        break;
-      }
-    }
-
-    return isSupported;
-  }
-
   refreshRatings() {
     const items = this.getJawbones();
     console.log('Finding movies/series...');
     for (const item of items) {
       const videoName = this.getVideoName(item);
       if (videoName && !this.cache.exists(videoName)) {
-        this.addRating(videoName, item).then(videoInfo => {
-          if(videoInfo.rating != null) {
-            console.log(`Note allociné pour '${videoInfo.name}' ajoutée.`);
-          } else {
-            console.log(`Note allociné pour '${videoInfo.name}' introuvable.`);
-          }
-        });
+        this.addRating(videoName, item);
       }
       if (this.cache.exists(videoName)) {
-        this.addRating(videoName, item, true).then(videoInfo => {
-            console.log(`Note allociné pour '${videoInfo.name}' récupérée en cache.`)
-          },
-        );
+        this.addRating(videoName, item, true);
       }
     }
   }
@@ -120,6 +99,7 @@ export default class Manager {
     let ratingElement;
     const videoElement = document.getElementById(videoInfo.hashId);
     if(!videoElement) {
+      console.log('on render');
       videoInfo = this.cache.save(videoInfo);
       if (isFailed) {
         ratingElement = this.renderFailedRating(element, videoInfo);
@@ -128,7 +108,6 @@ export default class Manager {
       }
       element.getElementsByClassName('jawbone-overview-info')[0].prepend(ratingElement);
     }
-
   }
 
   renderSucceedRating(element, videoInfo) {

--- a/src/http/Allocine.js
+++ b/src/http/Allocine.js
@@ -12,19 +12,22 @@ export default class AllocineClient {
       if (response.ok) {
         const body = await response.json();
         if (!body.error && body.results.length > 0) {
-          const firstResult = body.results[0];
-          return {
-            name: search,
-            id: firstResult.entity_id,
-            type: firstResult.entity_type,
-          };
+          for(const result of body.results) {
+            if(result.entity_type === 'series' || result.entity_type === 'movie') {
+              return {
+                name: search,
+                id: result.entity_id,
+                type: result.entity_type,
+              };
+            }
+          }
         }
       }
 
       return {
         name: search,
         id: null,
-        type: null
+        type: null,
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,6 @@
 import Manager from './dom/Manager';
 
-const observerConfig = {
-  childList: true,
-  subtree: true,
-  attributes: false,
-  characterData: false,
-};
 const manager = new Manager();
-manager.refreshRatings();
-
-const findRatings = async (mutations) => {
-  if (!manager.supports(mutations)) {
-    // MutationsEvents does not concerns jawbone
-    return;
-  }
+setInterval(() => {
   manager.refreshRatings();
-};
-
-const observer = new MutationObserver(findRatings);
-observer.observe(document.getElementsByClassName('mainView')[0], observerConfig);
-
+}, 2000);


### PR DESCRIPTION
# Fixes
- Stop listening DOM events with MutationObserver to prevent performance issue and asynchronous call for the same objects
- Use a basic setInterval to refresh the score of the video showed
- Prevent the case when allocine reply with another thing than a movie/series (like actor) bypass these results
