### PR TITLE
Release 1.2.3

### DIFF
--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "NoteFlix",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Permet d'avoir les scores et avis AlloCiné/SensCritique sur Netflix",
   "icons": {
     "48": "images/logo-48.png",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "NoteFlix",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Permet d'avoir les scores et avis AlloCiné/SensCritique sur Netflix",
   "icons": {
     "48": "images/logo-48.png",

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ const isLoaded = (mutation) => {
 }
 
 const observer = new MutationObserver((mutations) => {
+  console.log(mutations)
   // Only listen mutation of added jawBones
   const jawboneMutation = mutations.filter(mutation => {
     return clickedOnVideoJawBone(mutation) ||
@@ -50,4 +51,5 @@ const observer = new MutationObserver((mutations) => {
     manager.refreshRatings()
   }
 })
-observer.observe(document.querySelector('.mainView'), observerConfig)
+
+observer.observe(document.getElementById('appMountPoint'), observerConfig)

--- a/webpack_chrome.config.js
+++ b/webpack_chrome.config.js
@@ -1,19 +1,19 @@
-const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
+const path = require('path')
+const CopyPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   entry: {
-    index:  './src/index.js',
-    background:  './src/background.js',
+    index: './src/index.js',
+    background: './src/background.js'
   },
   plugins: [
     new CopyPlugin([
       { from: 'images/logo*', to: '.' },
-      { from: 'manifest_chrome.json', to: 'manifest.json'}
-    ]),
+      { from: 'manifest_chrome.json', to: 'manifest.json' }
+    ])
   ],
   output: {
     path: path.resolve(__dirname, 'dist/chrome/main'),
-    filename: '[name]/index.js',
+    filename: '[name]/index.js'
   }
-};
+}

--- a/webpack_firefox.config.js
+++ b/webpack_firefox.config.js
@@ -1,19 +1,19 @@
-const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
+const path = require('path')
+const CopyPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   entry: {
-    index:  './src/index.js',
-    background:  './src/background.js',
+    index: './src/index.js',
+    background: './src/background.js'
   },
   plugins: [
     new CopyPlugin([
       { from: 'images/logo*', to: '.' },
-      { from: 'manifest_firefox.json', to: 'manifest.json'}
-    ]),
+      { from: 'manifest_firefox.json', to: 'manifest.json' }
+    ])
   ],
   output: {
     path: path.resolve(__dirname, 'dist/firefox/main'),
-    filename: '[name]/index.js',
+    filename: '[name]/index.js'
   }
-};
+}


### PR DESCRIPTION
# Description
Suite à 4 avis négatifs sur Chrome stipulant que l'extension ne marchait pas, j'ai investigué de mon coté pour me rendre compte que lors de la sélection d'un profil netflix (c'est à dire en première connexion ou quand on veut changer de profil) l'extension n'était pas chargée. 

L'explication est simple, l'extension écoute une modification du noeud DOM ".mainView" qui parfois est crée dynamiquement donc au chargement de la page, on écoute sur un noeud DOM qui n'existe pas, résultat, aucun évènement n'est écouté et l'extension ne peut pas se déclencher.

# Solution
On écoute désormais tout le noeud de l'application `#appMountPoint`, ce qui revient à écouter tout le `body` pour s'assurer de ne pas perdre un évènement en route.